### PR TITLE
feat: add DISCOVERED item auto-creation as GitHub issues

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -33,6 +33,7 @@ bash scripts/test-skills-structure.sh
 
 | 日時 | 機能名 | フェーズ |
 |------|--------|---------|
+| 2026-02-07 | discovered-issue-creation | DONE |
 | 2026-02-07 | v5-release-docs | DONE |
 | 2026-02-07 | architect-refactorer-init | DONE |
 | 2026-02-07 | tdd-orchestrate-skill | DONE |
@@ -57,7 +58,7 @@ bash scripts/test-skills-structure.sh
 
 | 指標 | 現状 | 目標 |
 |------|------|------|
-| Cycle docs | 65 | - |
+| Cycle docs | 66 | - |
 | Open Issues | 0 | 0 |
 | Plugin数 | 10 | - |
 

--- a/docs/cycles/20260206_discovered-issue-creation.md
+++ b/docs/cycles/20260206_discovered-issue-creation.md
@@ -1,0 +1,231 @@
+---
+feature: discovered-issue-creation
+cycle: 20260206_discovered-issue-creation
+phase: DONE
+created: 2026-02-06 23:00
+updated: 2026-02-06 23:50
+---
+
+# DISCOVERED Issue Auto-Creation
+
+## Scope Definition
+
+### In Scope
+- [ ] PdMがDISCOVERED項目をスコープ内/外に判断するロジック追加
+- [ ] スコープ外項目を `gh issue create` でGitHub issueに起票
+- [ ] tdd-orchestrate (Agent Teams) での対応
+- [ ] tdd-review (subagent) での対応
+
+### Out of Scope
+- severity別ラベル付与 (Reason: シンプル形式を採用)
+- issue テンプレート (Reason: DISCOVERED内容をbodyに記載するだけ)
+- 自動アサイン (Reason: 起票のみ)
+
+### Files to Change (target: 10 or less)
+- plugins/tdd-core/skills/tdd-orchestrate/SKILL.md (edit)
+- plugins/tdd-core/skills/tdd-orchestrate/reference.md (edit)
+- plugins/tdd-core/skills/tdd-orchestrate/steps-teams.md (edit)
+- plugins/tdd-core/skills/tdd-orchestrate/steps-subagent.md (edit)
+- plugins/tdd-core/skills/tdd-review/SKILL.md (edit)
+- plugins/tdd-core/skills/tdd-review/reference.md (edit)
+
+## Environment
+
+### Scope
+- Layer: N/A (Plugin skill definitions)
+- Plugin: tdd-core
+- Risk: 40 (WARN)
+
+### Runtime
+- Bash: 3.2.57
+- gh CLI: 2.74.2
+
+### Dependencies (key packages)
+- gh: 2.74.2 (GitHub CLI for issue creation)
+
+## Context & Dependencies
+
+### Reference Documents
+- plugins/tdd-core/skills/quality-gate/reference.md - quality-gate出力形式
+- plugins/tdd-core/skills/tdd-orchestrate/reference.md - PdM判断基準
+- plugins/tdd-core/skills/tdd-review/reference.md - DISCOVERED handling
+
+### Dependent Features
+- quality-gate: DISCOVERED項目の生成元
+- tdd-orchestrate: PdM判断ロジック
+- tdd-review: subagentモードでのDISCOVERED処理
+
+### Related Issues/PRs
+- (none)
+
+## Test List
+
+### TODO
+
+#### tdd-orchestrate
+- [ ] TC-01: SKILL.md の Block 2 にDISCOVERED処理が記載されていること
+- [ ] TC-02: steps-teams.md の REVIEW 自律判断後に「DISCOVERED判断」ステップが存在すること
+- [ ] TC-03: steps-teams.md に `gh issue create` コマンドテンプレートが記載されていること
+- [ ] TC-04: steps-subagent.md の Block 2 REVIEW後に DISCOVERED 処理が記載されていること
+- [ ] TC-05: reference.md の PdM 責務に「DISCOVERED issue 起票」が追加されていること
+
+#### tdd-review (subagent)
+- [ ] TC-06: SKILL.md に Step 6 として DISCOVERED issue 起票ステップが存在すること（リナンバ済み）
+- [ ] TC-07: reference.md に issue 起票の判断基準・コマンド詳細が記載されていること
+
+#### 共通
+- [ ] TC-08: issue タイトル形式が `[DISCOVERED] <要約>` であること
+- [ ] TC-09: issue に `discovered` ラベルが指定されていること
+- [ ] TC-10: DISCOVERED が空の場合はissue起票をスキップする記載があること
+- [ ] TC-11: `gh auth status` による事前チェックが記載されていること
+- [ ] TC-12: ユーザー確認ゲート（issue作成前の承認）が記載されていること
+- [ ] TC-13: 重複防止（`→ #<番号>` 付き項目のスキップ）が記載されていること
+- [ ] TC-14: issue body に Cycle doc パス・Phase・Reviewer が含まれること
+- [ ] TC-15: 既存の Plugin 構造テスト (`test-plugins-structure.sh`) が通ること
+
+### WIP
+(none)
+
+### DISCOVERED
+(none)
+
+### DONE
+TC-01 ~ TC-15 (全件 PASS)
+
+## Implementation Notes
+
+### Goal
+quality-gateのDISCOVERED項目をPdMが判断し、スコープ外のものをGitHub issueに自動起票する。
+Agent Teams / subagent 両モード対応。issue形式はシンプル (タイトル + DISCOVERED内容のbody、ラベルは 'discovered' のみ)。
+
+### Background
+quality-gateが問題を発見した場合、現状は2つのパスしかない:
+1. BLOCK → GREENに戻って修正（スコープ内で対応）
+2. PASS/WARN → そのままCOMMIT（発見事項を無視）
+
+WARN の issues や DISCOVERED に追加された「スコープ外」の項目は、
+記録されるだけで追跡されない。これは知見の損失につながる。
+
+PdM がスコープ内/外を判断し、スコープ外をGitHub issueに起票することで、
+サイクルを肥大化させずに知見を保持する。
+
+### Design Approach
+
+#### 挿入ポイント
+REVIEW の PASS/WARN 判定後、COMMIT の前に新ステップを追加:
+
+```
+REVIEW → PASS/WARN → [DISCOVERED判断 + issue起票] → COMMIT
+       → BLOCK → GREEN再実行（変更なし）
+```
+
+#### データソース (plan-review 指摘対応)
+DISCOVERED 項目は **Cycle doc の DISCOVERED セクション** から読み取る:
+- quality-gate の reviewer が発見した問題 → tdd-review が DISCOVERED セクションに記録
+- RED/GREEN 中に手動で追加された項目
+- quality-gate JSON issues[] は直接の入力ソースではない（BLOCK/WARN 判定に使用済み）
+
+#### PdM判断基準
+Cycle doc の DISCOVERED セクションの各項目を判断:
+- **スコープ内** → RED に戻って修正（既存フロー通り）
+- **スコープ外** → GitHub issue に起票
+
+#### ユーザー確認ゲート (plan-review 指摘対応)
+issue 作成は外部副作用のため、PdM 自律判断ではなくユーザー承認を求める:
+```
+DISCOVERED items found:
+1. [項目1の要約]
+2. [項目2の要約]
+
+GitHub issue を作成しますか? (Y/n/skip)
+```
+
+#### issue起票コマンド
+```bash
+# 事前チェック (plan-review 指摘対応)
+gh auth status 2>/dev/null || echo "gh CLI未認証。issue起票をスキップします。"
+
+# 起票
+gh issue create --title "[DISCOVERED] <要約>" --body "<詳細>" --label "discovered"
+```
+
+issue body テンプレート:
+```
+## 発見元
+- Cycle: docs/cycles/<cycle-doc>.md
+- Phase: REVIEW
+- Reviewer: <reviewer名 or 手動>
+
+## 内容
+<DISCOVERED セクションの記載内容>
+```
+
+#### 重複防止 (plan-review 指摘対応)
+起票済みの項目は Cycle doc の DISCOVERED セクションで `→ #<issue番号>` を付記:
+```
+### DISCOVERED
+- パフォーマンス問題の可能性 → #42
+- エラーハンドリング不足 → #43
+```
+既に `→ #` が付いている項目はスキップする。
+
+#### 両モード対応
+- **Agent Teams (tdd-orchestrate)**: steps-teams.md の Phase 3 自律判断後に追加
+- **Subagent (tdd-review)**: SKILL.md Step 6 として追加（既存 Step 5,6 を 6,7 にリナンバ）
+
+#### 変更ファイル一覧
+1. `tdd-orchestrate/SKILL.md` - Block 2 にDISCOVERED処理を追記
+2. `tdd-orchestrate/reference.md` - PdM責務にissue起票を追加
+3. `tdd-orchestrate/steps-teams.md` - REVIEW後にDISCOVERED判断ステップ追加
+4. `tdd-orchestrate/steps-subagent.md` - Block 2 のREVIEW後にDISCOVERED処理追加
+5. `tdd-review/SKILL.md` - Step 6としてDISCOVERED issue起票ステップ追加（リナンバ）
+6. `tdd-review/reference.md` - issue起票の判断基準・コマンド詳細を追加
+
+## Progress Log
+
+### 2026-02-06 23:00 - INIT
+- Cycle doc created
+- Scope: tdd-orchestrate + tdd-review の両方にissue起票機能追加
+- Risk: 40 (WARN) - 既存ワークフローへの追加、破壊的変更なし
+
+### 2026-02-06 23:10 - PLAN
+- 設計完了: REVIEW PASS/WARN後にDISCOVERED判断ステップを挿入
+- 変更ファイル5つ: orchestrate(3) + review(2)
+- Test List: 10ケース (orchestrate 4, review 2, 共通 4)
+
+### 2026-02-06 23:20 - plan-review (WARN: 55)
+- scope: 38, architecture: 35, risk: 55, product: 52, usability: 52
+- 反映: データソース明確化、gh事前チェック、重複防止、ユーザー確認ゲート
+- 反映: Step 5.5→Step 6リナンバ、tdd-orchestrate/SKILL.md追加（計6ファイル）
+- 反映: issue bodyテンプレート、DISCOVERED項目に起票済みマーク
+- Test List: 15ケースに拡充
+
+### 2026-02-06 23:30 - RED
+- テストスクリプト作成: scripts/test-discovered-issue-creation.sh
+- 14/15 FAIL (TC-15のみ既存テストでPASS)
+
+### 2026-02-06 23:35 - GREEN
+- 6ファイル編集: orchestrate(4) + review(2)
+- 15/15 PASS + 既存 136/136 PASS
+
+### 2026-02-06 23:40 - REFACTOR
+- Progress Checklist に DISCOVERED ステップ反映
+- 全テスト維持
+
+### 2026-02-06 23:45 - REVIEW
+- quality-gate WARN: 72
+- correctness: 72, performance: 72, security: 72, guidelines: 92, product: 28, usability: 62
+- DISCOVERED: (none) → issue起票スキップ
+
+---
+
+## Next Steps
+
+1. [Done] INIT
+2. [Done] PLAN
+3. [Done] plan-review (WARN: 55, 指摘反映済み)
+4. [Done] RED (14/15 FAIL confirmed)
+5. [Done] GREEN (15/15 PASS)
+6. [Done] REFACTOR (Checklist反映)
+7. [Done] REVIEW (quality-gate WARN: 72)
+8. [Done] COMMIT

--- a/plugins/tdd-core/skills/tdd-orchestrate/SKILL.md
+++ b/plugins/tdd-core/skills/tdd-orchestrate/SKILL.md
@@ -12,7 +12,7 @@ TDDサイクル全体をPdM (Product Manager) として管理するオーケス�
 ```
 tdd-orchestrate Progress:
 - [ ] Block 1: INIT → PLAN → plan-review → 自律判断
-- [ ] Block 2: RED → GREEN → REFACTOR → REVIEW → 自律判断
+- [ ] Block 2: RED → GREEN → REFACTOR → REVIEW → 自律判断 → DISCOVERED
 - [ ] Block 3: COMMIT → 完了
 ```
 
@@ -37,7 +37,8 @@ tdd-orchestrate Progress:
 2. **GREEN**: green-worker に実装を委譲
 3. **REFACTOR**: refactorer にリファクタリングを委譲
 4. **REVIEW**: quality-gate で 6 reviewer レビュー
-5. **自律判断**: PASS/WARN → Block 3 へ、BLOCK → GREEN 再実行
+5. **自律判断**: PASS/WARN → DISCOVERED 判断 → Block 3 へ、BLOCK → GREEN 再実行
+6. **DISCOVERED**: スコープ外項目を GitHub issue に起票（ユーザー確認後）
 
 ### Block 3: Finalization
 

--- a/plugins/tdd-core/skills/tdd-orchestrate/reference.md
+++ b/plugins/tdd-core/skills/tdd-orchestrate/reference.md
@@ -14,6 +14,7 @@ PdM (Product Manager) オーケストレータの詳細ガイド。
 | Context 管理 | Cycle doc 読み書き、Phase 状態追跡 |
 | Verification Gate | テスト実行、成功/失敗確認 |
 | Git 操作 | commit, status, diff |
+| DISCOVERED issue 起票 | スコープ外の DISCOVERED 項目を GitHub issue に起票 |
 
 ### やらないこと
 
@@ -100,3 +101,51 @@ tdd-orchestrate Progress:
 ```
 
 これにより、ユーザーは長時間の自律実行中も進捗を把握できる。
+
+## DISCOVERED issue 起票
+
+REVIEW の PASS/WARN 後、COMMIT の前に実行する。
+
+### データソース
+
+Cycle doc の `### DISCOVERED` セクションから読み取る。
+
+### 判断基準
+
+| 条件 | アクション |
+|------|-----------|
+| DISCOVERED が空 or `(none)` | スキップ（issue起票なし） |
+| 全項目が起票済み（`→ #` 付き） | スキップ |
+| 未起票の項目あり | ユーザー確認後に起票 |
+
+### 事前チェック
+
+```bash
+gh auth status 2>/dev/null || echo "gh CLI未認証。issue起票をスキップします。"
+```
+
+`gh` が利用不可の場合、DISCOVERED 項目を Cycle doc に残したまま COMMIT へ進行する。
+
+### ユーザー確認ゲート
+
+GitHub issue 作成は外部副作用のため、PdM 自律判断ではなくユーザー承認を求める:
+
+```
+DISCOVERED items found:
+1. [項目1の要約]
+2. [項目2の要約]
+
+GitHub issue を作成しますか? (Y/n/skip)
+```
+
+### 重複防止
+
+起票済みの項目は Cycle doc で `→ #<issue番号>` マークが付く:
+
+```markdown
+### DISCOVERED
+- パフォーマンス問題 → #42
+- エラーハンドリング不足 → #43
+```
+
+`→ #` が付いている項目は起票をスキップする。

--- a/plugins/tdd-core/skills/tdd-orchestrate/steps-subagent.md
+++ b/plugins/tdd-core/skills/tdd-orchestrate/steps-subagent.md
@@ -22,9 +22,15 @@ Skill(tdd-core:tdd-red)
 → 自動的に tdd-green を実行
 → 自動的に tdd-refactor を実行
 → 自動的に tdd-review (quality-gate) を実行
-→ PASS/WARN → Block 3 へ
+→ PASS/WARN → DISCOVERED 判断へ
 → BLOCK → tdd-green を再実行
 ```
+
+### DISCOVERED 判断
+
+REVIEW が PASS/WARN の場合、Cycle doc の DISCOVERED セクションを確認し、
+スコープ外の未起票項目を GitHub issue に起票する。
+詳細は [reference.md](reference.md#discovered-issue-起票) を参照。
 
 ## Block 3: Finalization
 

--- a/plugins/tdd-core/skills/tdd-orchestrate/steps-teams.md
+++ b/plugins/tdd-core/skills/tdd-orchestrate/steps-teams.md
@@ -85,8 +85,44 @@ guidelines-reviewer, product-reviewer, usability-reviewer
 
 ### 自律判断
 
-- PASS/WARN → Block 3 (Phase 4) へ進行
+- PASS/WARN → DISCOVERED 判断へ進行
 - BLOCK → green-worker を再起動して修正（max 1回再試行）
+
+### DISCOVERED 判断
+
+REVIEW が PASS/WARN の場合、Cycle doc の DISCOVERED セクションを確認:
+
+1. DISCOVERED が空 → スキップして Block 3 へ
+2. 起票済み（`→ #` 付き）の項目 → スキップ
+3. 未起票の項目がある場合:
+
+```bash
+# 事前チェック
+gh auth status 2>/dev/null || echo "gh CLI未認証。issue起票をスキップします。"
+```
+
+ユーザーに確認:
+```
+DISCOVERED items found:
+1. [項目の要約]
+GitHub issue を作成しますか? (Y/n/skip)
+```
+
+承認後、各項目に対して:
+```bash
+gh issue create --title "[DISCOVERED] <要約>" --body "$(cat <<'EOF'
+## 発見元
+- Cycle: docs/cycles/<cycle-doc>.md
+- Phase: REVIEW
+- Reviewer: <reviewer名 or 手動>
+
+## 内容
+<DISCOVERED セクションの記載内容>
+EOF
+)" --label "discovered"
+```
+
+起票後、Cycle doc の DISCOVERED セクションに `→ #<issue番号>` を付記。
 
 ## Phase 4: Block 3 - Finalization
 

--- a/plugins/tdd-core/skills/tdd-review/SKILL.md
+++ b/plugins/tdd-core/skills/tdd-review/SKILL.md
@@ -18,6 +18,7 @@ REVIEW Progress:
 - [ ] 静的解析実行（エラー0件）
 - [ ] quality-gate 実行（必須・スキップ不可）
 - [ ] コードフォーマッタ実行
+- [ ] DISCOVERED issue 起票（該当項目がある場合）
 - [ ] Cycle doc更新
 - [ ] COMMITフェーズへ誘導
 ```
@@ -68,7 +69,12 @@ quality-gateスキルを必ず実行する。スキップ不可。4エージェ�
 black . && isort .  # Python
 ```
 
-### Step 6: 品質基準クリア確認
+### Step 6: DISCOVERED issue 起票
+
+Cycle doc の DISCOVERED セクションを確認し、スコープ外の未起票項目を GitHub issue に起票する。
+DISCOVERED が空の場合はスキップ。詳細: [reference.md](reference.md#discovered-issue-起票)
+
+### Step 7: 品質基準クリア確認
 
 結果を表示し、ユーザー承認を求める。COMMIT判断はユーザーが行う。
 

--- a/scripts/test-discovered-issue-creation.sh
+++ b/scripts/test-discovered-issue-creation.sh
@@ -1,0 +1,226 @@
+#!/bin/bash
+# Test: discovered-issue-creation
+# Cycle doc: docs/cycles/20260206_discovered-issue-creation.md
+
+set -e
+
+PLUGIN_DIR="plugins/tdd-core/skills"
+ERRORS=0
+
+echo "=== DISCOVERED Issue Auto-Creation Tests ==="
+echo ""
+
+# --- tdd-orchestrate ---
+echo "--- tdd-orchestrate ---"
+
+ORCH_SKILL="$PLUGIN_DIR/tdd-orchestrate/SKILL.md"
+ORCH_REF="$PLUGIN_DIR/tdd-orchestrate/reference.md"
+ORCH_TEAMS="$PLUGIN_DIR/tdd-orchestrate/steps-teams.md"
+ORCH_SUB="$PLUGIN_DIR/tdd-orchestrate/steps-subagent.md"
+
+# TC-01: SKILL.md の Block 2 にDISCOVERED処理が記載されていること
+echo -n "TC-01: tdd-orchestrate SKILL.md Block 2 has DISCOVERED processing... "
+if grep -A20 "Block 2" "$ORCH_SKILL" 2>/dev/null | grep -qi "DISCOVERED"; then
+    echo "PASS"
+else
+    echo "FAIL"
+    ERRORS=$((ERRORS + 1))
+fi
+
+# TC-02: steps-teams.md の REVIEW 自律判断後に「DISCOVERED判断」ステップが存在すること
+echo -n "TC-02: steps-teams.md has DISCOVERED judgment step after REVIEW... "
+if grep -qi "DISCOVERED" "$ORCH_TEAMS" 2>/dev/null; then
+    echo "PASS"
+else
+    echo "FAIL"
+    ERRORS=$((ERRORS + 1))
+fi
+
+# TC-03: steps-teams.md に gh issue create コマンドテンプレートが記載されていること
+echo -n "TC-03: steps-teams.md has gh issue create command template... "
+if grep -q "gh issue create" "$ORCH_TEAMS" 2>/dev/null; then
+    echo "PASS"
+else
+    echo "FAIL"
+    ERRORS=$((ERRORS + 1))
+fi
+
+# TC-04: steps-subagent.md の Block 2 REVIEW後に DISCOVERED 処理が記載されていること
+echo -n "TC-04: steps-subagent.md has DISCOVERED processing after REVIEW... "
+if grep -qi "DISCOVERED" "$ORCH_SUB" 2>/dev/null; then
+    echo "PASS"
+else
+    echo "FAIL"
+    ERRORS=$((ERRORS + 1))
+fi
+
+# TC-05: reference.md の PdM 責務に「DISCOVERED issue 起票」が追加されていること
+echo -n "TC-05: reference.md PdM responsibilities include DISCOVERED issue creation... "
+if grep -qi "DISCOVERED" "$ORCH_REF" 2>/dev/null && grep -q "issue" "$ORCH_REF" 2>/dev/null; then
+    echo "PASS"
+else
+    echo "FAIL"
+    ERRORS=$((ERRORS + 1))
+fi
+
+echo ""
+
+# --- tdd-review ---
+echo "--- tdd-review ---"
+
+REVIEW_SKILL="$PLUGIN_DIR/tdd-review/SKILL.md"
+REVIEW_REF="$PLUGIN_DIR/tdd-review/reference.md"
+
+# TC-06: SKILL.md に Step 6 として DISCOVERED issue 起票ステップが存在すること（リナンバ済み）
+echo -n "TC-06: tdd-review SKILL.md has DISCOVERED step (renumbered)... "
+if grep -q "DISCOVERED" "$REVIEW_SKILL" 2>/dev/null && grep -qi "issue" "$REVIEW_SKILL" 2>/dev/null; then
+    echo "PASS"
+else
+    echo "FAIL"
+    ERRORS=$((ERRORS + 1))
+fi
+
+# TC-07: reference.md に issue 起票の判断基準・コマンド詳細が記載されていること
+echo -n "TC-07: tdd-review reference.md has issue creation criteria and command... "
+if grep -q "gh issue create" "$REVIEW_REF" 2>/dev/null && grep -qi "DISCOVERED" "$REVIEW_REF" 2>/dev/null; then
+    echo "PASS"
+else
+    echo "FAIL"
+    ERRORS=$((ERRORS + 1))
+fi
+
+echo ""
+
+# --- 共通 ---
+echo "--- Common ---"
+
+# TC-08: issue タイトル形式が [DISCOVERED] <要約> であること
+echo -n "TC-08: Issue title format is [DISCOVERED] <summary>... "
+DISCOVERED_TITLE_FOUND=0
+for f in "$ORCH_TEAMS" "$ORCH_SUB" "$REVIEW_REF"; do
+    if grep -q '\[DISCOVERED\]' "$f" 2>/dev/null; then
+        DISCOVERED_TITLE_FOUND=1
+        break
+    fi
+done
+if [ "$DISCOVERED_TITLE_FOUND" -eq 1 ]; then
+    echo "PASS"
+else
+    echo "FAIL"
+    ERRORS=$((ERRORS + 1))
+fi
+
+# TC-09: issue に discovered ラベルが指定されていること
+echo -n "TC-09: Issue has 'discovered' label... "
+LABEL_FOUND=0
+for f in "$ORCH_TEAMS" "$ORCH_SUB" "$REVIEW_REF"; do
+    if grep -q '\-\-label.*discovered\|label.*"discovered"' "$f" 2>/dev/null; then
+        LABEL_FOUND=1
+        break
+    fi
+done
+if [ "$LABEL_FOUND" -eq 1 ]; then
+    echo "PASS"
+else
+    echo "FAIL"
+    ERRORS=$((ERRORS + 1))
+fi
+
+# TC-10: DISCOVERED が空の場合はissue起票をスキップする記載があること
+echo -n "TC-10: Skip issue creation when DISCOVERED is empty... "
+SKIP_FOUND=0
+for f in "$ORCH_TEAMS" "$ORCH_SUB" "$ORCH_REF" "$REVIEW_SKILL" "$REVIEW_REF"; do
+    if grep -qi "DISCOVERED.*空\|DISCOVERED.*none.*スキップ\|DISCOVERED.*スキップ\|DISCOVERED.*empty.*skip" "$f" 2>/dev/null; then
+        SKIP_FOUND=1
+        break
+    fi
+done
+if [ "$SKIP_FOUND" -eq 1 ]; then
+    echo "PASS"
+else
+    echo "FAIL"
+    ERRORS=$((ERRORS + 1))
+fi
+
+# TC-11: gh auth status による事前チェックが記載されていること
+echo -n "TC-11: gh auth status pre-check is documented... "
+AUTH_CHECK_FOUND=0
+for f in "$ORCH_TEAMS" "$ORCH_SUB" "$ORCH_REF" "$REVIEW_REF"; do
+    if grep -q "gh auth status" "$f" 2>/dev/null; then
+        AUTH_CHECK_FOUND=1
+        break
+    fi
+done
+if [ "$AUTH_CHECK_FOUND" -eq 1 ]; then
+    echo "PASS"
+else
+    echo "FAIL"
+    ERRORS=$((ERRORS + 1))
+fi
+
+# TC-12: ユーザー確認ゲート（issue作成前の承認）が記載されていること
+echo -n "TC-12: User confirmation gate before issue creation... "
+CONFIRM_FOUND=0
+for f in "$ORCH_TEAMS" "$ORCH_SUB" "$ORCH_REF" "$REVIEW_SKILL" "$REVIEW_REF"; do
+    if grep -qi "issue.*作成.*確認\|issue.*承認\|issue.*Y/n\|DISCOVERED.*確認.*ゲート\|GitHub issue.*確認" "$f" 2>/dev/null; then
+        CONFIRM_FOUND=1
+        break
+    fi
+done
+if [ "$CONFIRM_FOUND" -eq 1 ]; then
+    echo "PASS"
+else
+    echo "FAIL"
+    ERRORS=$((ERRORS + 1))
+fi
+
+# TC-13: 重複防止（→ #<番号> 付き項目のスキップ）が記載されていること
+echo -n "TC-13: Duplicate prevention (skip items with issue number)... "
+DEDUP_FOUND=0
+for f in "$ORCH_TEAMS" "$ORCH_SUB" "$ORCH_REF" "$REVIEW_REF"; do
+    if grep -q '→ #\|重複防止\|duplicate\|起票済み' "$f" 2>/dev/null; then
+        DEDUP_FOUND=1
+        break
+    fi
+done
+if [ "$DEDUP_FOUND" -eq 1 ]; then
+    echo "PASS"
+else
+    echo "FAIL"
+    ERRORS=$((ERRORS + 1))
+fi
+
+# TC-14: issue body に Cycle doc パス・Phase・Reviewer が含まれること
+echo -n "TC-14: Issue body includes Cycle doc path, Phase, Reviewer... "
+BODY_FOUND=0
+for f in "$ORCH_TEAMS" "$ORCH_SUB" "$REVIEW_REF"; do
+    if grep -qi "Cycle.*doc\|Phase\|Reviewer\|発見元" "$f" 2>/dev/null && grep -q "body" "$f" 2>/dev/null; then
+        BODY_FOUND=1
+        break
+    fi
+done
+if [ "$BODY_FOUND" -eq 1 ]; then
+    echo "PASS"
+else
+    echo "FAIL"
+    ERRORS=$((ERRORS + 1))
+fi
+
+# TC-15: 既存の Plugin 構造テスト (test-plugins-structure.sh) が通ること
+echo -n "TC-15: test-plugins-structure.sh passes... "
+if bash scripts/test-plugins-structure.sh >/dev/null 2>&1; then
+    echo "PASS"
+else
+    echo "FAIL"
+    ERRORS=$((ERRORS + 1))
+fi
+
+echo ""
+echo "=== Results ==="
+if [ "$ERRORS" -eq 0 ]; then
+    echo "All tests passed!"
+    exit 0
+else
+    echo "$ERRORS test(s) failed"
+    exit 1
+fi


### PR DESCRIPTION
## Summary
- PdMがquality-gate/REVIEWで発見されたDISCOVERED項目を判断し、スコープ外のものをGitHub issueに自動起票する機能を追加
- tdd-orchestrate（Agent Teams/Subagent両対応）とtdd-reviewの両方に対応
- ユーザー確認ゲート、gh auth事前チェック、重複防止（→ #番号）を実装

## Test plan
- [x] 15/15 feature tests PASS (scripts/test-discovered-issue-creation.sh)
- [x] 136/136 existing structure tests PASS
- [x] quality-gate WARN (72)

🤖 Generated with [Claude Code](https://claude.com/claude-code)